### PR TITLE
Avoid multiple highs or lows in a row

### DIFF
--- a/HarmonicPatterns/harmonic_functions.py
+++ b/HarmonicPatterns/harmonic_functions.py
@@ -64,8 +64,8 @@ class HarmonicDetector(object):
 
         zigzag_pattern = []
         direction = 0
-        changed = False
         for idx in range(1, len(df)):
+            changed = False
             highest_high = ta.MAX(df.high[:idx], timeperiod=period)[-1]
             lowest_low = ta.MIN(df.low[:idx], timeperiod=period)[-1]
 


### PR DESCRIPTION
If you have the same candle, setting new high and low, twice in a row `changed` or `direction` will not by updated resulting in an extra `pat` in the same direction. Final zigzag would be something like HLLHL, causing a division by zero later on.